### PR TITLE
rewrote spec to prove saxophone can read hyphen as underscore

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,5 @@ group :development, :test do
 end
 
 group :test do
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.3.13'
 end

--- a/spec/saxophone/sax_configure_spec.rb
+++ b/spec/saxophone/sax_configure_spec.rb
@@ -4,7 +4,7 @@ describe "Saxophone configure" do
   before do
     class A
       Saxophone.configure(A) do |c|
-        c.element :title
+        c.element :title_new
       end
     end
 
@@ -20,7 +20,7 @@ describe "Saxophone configure" do
       end
     end
 
-    xml = "<top><title>Test</title><b>Matched!</b><c>And Again</c></top>"
+    xml = "<top><title-new>Test</title-new><b>Matched!</b><c>And Again</c></top>"
     @a = A.parse xml
     @b = B.parse xml
     @c = C.parse xml
@@ -35,17 +35,17 @@ describe "Saxophone configure" do
   it { expect(@a).to be_a(A) }
   it { expect(@a).not_to be_a(B) }
   it { expect(@a).to be_a(Saxophone) }
-  it { expect(@a.title).to eq("Test") }
+  it { expect(@a.title_new).to eq("Test") }
   it { expect(@b).to be_a(A) }
   it { expect(@b).to be_a(B) }
   it { expect(@b).to be_a(Saxophone) }
-  it { expect(@b.title).to eq("Test") }
+  it { expect(@b.title_new).to eq("Test") }
   it { expect(@b.b).to eq("Matched!") }
   it { expect(@c).to be_a(A) }
   it { expect(@c).to be_a(B) }
   it { expect(@c).to be_a(C) }
   it { expect(@c).to be_a(Saxophone) }
-  it { expect(@c.title).to eq("Test") }
+  it { expect(@c.title_new).to eq("Test") }
   it { expect(@c.b).to eq("Matched!") }
   it { expect(@c.c).to eq("And Again") }
 end


### PR DESCRIPTION
In this [issue](https://github.com/Absolventa/saxophone/issues/1) @neumanrq describes a struggle with reading elements in the XML, that contain a hyphen. I was being a "Streberin" and rewriting the spec in order to see, what exactly breaks, and was blown away by the green results.
Can it be that old Saxmachine couldn't read the hyphen, but Saxophone can? We don't know. But this means, that we could possibly rewrite some adapter that had a workaround for this case and just use the good old underscore way of referencing the element.